### PR TITLE
Check for published tricks before returning trick of day

### DIFF
--- a/plugins/offline/tricks/components/TrickDetail.php
+++ b/plugins/offline/tricks/components/TrickDetail.php
@@ -47,6 +47,10 @@ class TrickDetail extends ComponentBase
 
     public function init()
     {
+        if (!Trick::published()->count()) {
+            return; 
+        }
+        
         $this->trick = $this->page['trick'] = Trick
             ::published()
             ->with(['tags', 'comments', 'topics', 'author'])


### PR DESCRIPTION
After cloning the repo to begin development, I ran into an error related to the trick of the day in the TrickDetail component:
![image](https://user-images.githubusercontent.com/28734844/74867792-e71e5000-531a-11ea-9288-ad3ea2ff0a5c.png)

This appears to be due to the fact that there are no published tricks when the project is initially set up. A quick check for a published trick count can prevent the error from being thrown.