### PR TITLE
Add feature to list author tricks

### DIFF
--- a/plugins/offline/tricks/components/TrickList.php
+++ b/plugins/offline/tricks/components/TrickList.php
@@ -5,6 +5,7 @@ use OFFLINE\Tricks\Models\Tag;
 use OFFLINE\Tricks\Models\Topic;
 use OFFLINE\Tricks\Models\Trick;
 use RainLab\User\Facades\Auth;
+use RainLab\User\Models\User;
 
 class TrickList extends ComponentBase
 {
@@ -75,6 +76,11 @@ class TrickList extends ComponentBase
         }
         if ($this->property('user')) {
             $this->user = Auth::getUser();
+        } else if ($this->property('username')) {
+            $this->user = User::where('username', $this->property('username'))->first();
+            if ( ! $this->user ) {
+                return $this->controller->run('404');
+            }
         }
         if ($this->property('unpublished')) {
             $this->publishedOnly = false;

--- a/themes/october-tricks/pages/author-tricks.htm
+++ b/themes/october-tricks/pages/author-tricks.htm
@@ -20,10 +20,10 @@ function onStart() {
 <section class="content content--no-sidebar content--pull-up">
     <div class="box box--padding-1">
         <h1 class="box__heading">
-            Tricks by author
+            Tricks by {{ trickListAuthor.property('username') }}
         </h1>
         <div class="box__subheading">
-            This is a list of all the tricks author has submitted
+            This is a list of all the tricks {{ trickListAuthor.property('username') }} has submitted.
         </div>
 
         {% if trickListAuthor.tricks.count() > 0 %}

--- a/themes/october-tricks/pages/author-tricks.htm
+++ b/themes/october-tricks/pages/author-tricks.htm
@@ -1,0 +1,41 @@
+title = "User Tricks"
+url = "/authors/:username/tricks"
+layout = "default"
+is_hidden = 0
+
+[session]
+security = "user"
+redirect = "account"
+
+[trickList trickListAuthor]
+user = 0
+unpublished = 0
+limit = 10
+username = "{{ :username }}"
+==
+function onStart() {
+    $this['hideSearchbox'] = true;
+}
+==
+<section class="content content--no-sidebar content--pull-up">
+    <div class="box box--padding-1">
+        <h1 class="box__heading">
+            Tricks by author
+        </h1>
+        <div class="box__subheading">
+            This is a list of all the tricks author has submitted
+        </div>
+
+        {% if trickListAuthor.tricks.count() > 0 %}
+            {% component 'trickListAuthor' %}
+        {% else %}
+            <a href="{{ 'trick-form' | page({slug: ''}) }}"
+               class="well">
+                <div class="well__heading">There is nothing to see here</div>
+                <div class="well__cta">
+                    Submit your first trick now
+                </div>
+            </a>
+        {% endif %}
+    </div>
+</section>

--- a/themes/october-tricks/pages/homepage.htm
+++ b/themes/october-tricks/pages/homepage.htm
@@ -39,7 +39,7 @@ limit = 5
                 </a>
             </h3>
             <div class="trick-of-the-day__meta">
-                by <a href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
+                by <a class="author" href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
             </div>
             {% partial 'trickDetail/tags' tags=trickDetail.trick.tags %}
         </div>

--- a/themes/october-tricks/pages/homepage.htm
+++ b/themes/october-tricks/pages/homepage.htm
@@ -39,7 +39,7 @@ limit = 5
                 </a>
             </h3>
             <div class="trick-of-the-day__meta">
-                by {{ trick.author.username }}
+                by <a href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
             </div>
             {% partial 'trickDetail/tags' tags=trickDetail.trick.tags %}
         </div>

--- a/themes/october-tricks/pages/homepage.htm
+++ b/themes/october-tricks/pages/homepage.htm
@@ -39,7 +39,7 @@ limit = 5
                 </a>
             </h3>
             <div class="trick-of-the-day__meta">
-                by <a class="author" href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
+                by <a class="author" href="{{ 'author-tricks' | page({username: trick.author.username}) }}">{{ trick.author.username }}</a>
             </div>
             {% partial 'trickDetail/tags' tags=trickDetail.trick.tags %}
         </div>

--- a/themes/october-tricks/partials/medium-trick.htm
+++ b/themes/october-tricks/partials/medium-trick.htm
@@ -19,7 +19,7 @@
         {% else %}
             <div class="medium-trick__meta">
                 <div class="medium-trick__author">
-                    by {{ trick.author.username }}
+                    by <a href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
                 </div>
             </div>
             <div class="medium-trick__tags">

--- a/themes/october-tricks/partials/medium-trick.htm
+++ b/themes/october-tricks/partials/medium-trick.htm
@@ -19,7 +19,7 @@
         {% else %}
             <div class="medium-trick__meta">
                 <div class="medium-trick__author">
-                    by <a class="author" href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
+                    by <a class="author" href="{{ 'author-tricks' | page({username: trick.author.username}) }}">{{ trick.author.username }}</a>
                 </div>
             </div>
             <div class="medium-trick__tags">

--- a/themes/october-tricks/partials/medium-trick.htm
+++ b/themes/october-tricks/partials/medium-trick.htm
@@ -19,7 +19,7 @@
         {% else %}
             <div class="medium-trick__meta">
                 <div class="medium-trick__author">
-                    by <a href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
+                    by <a class="author" href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
                 </div>
             </div>
             <div class="medium-trick__tags">

--- a/themes/october-tricks/partials/small-trick.htm
+++ b/themes/october-tricks/partials/small-trick.htm
@@ -6,7 +6,7 @@
         </span>
     </a>
     <a href="{{ 'trick' | page({slug:trick.slug}) }}" class="small-trick__subtitle">
-        by <a class="author" href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
+        by <a class="author" href="{{ 'author-tricks' | page({username: trick.author.username}) }}">{{ trick.author.username }}</a>
     </a>
     <div class="small-trick__tags">
         {% partial 'trickDetail/tags' tags=trick.tags nowrap=true %}

--- a/themes/october-tricks/partials/small-trick.htm
+++ b/themes/october-tricks/partials/small-trick.htm
@@ -6,7 +6,7 @@
         </span>
     </a>
     <a href="{{ 'trick' | page({slug:trick.slug}) }}" class="small-trick__subtitle">
-        by {{ trick.author.username }}
+        by <a href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
     </a>
     <div class="small-trick__tags">
         {% partial 'trickDetail/tags' tags=trick.tags nowrap=true %}

--- a/themes/october-tricks/partials/small-trick.htm
+++ b/themes/october-tricks/partials/small-trick.htm
@@ -6,7 +6,7 @@
         </span>
     </a>
     <a href="{{ 'trick' | page({slug:trick.slug}) }}" class="small-trick__subtitle">
-        by <a href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
+        by <a class="author" href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>
     </a>
     <div class="small-trick__tags">
         {% partial 'trickDetail/tags' tags=trick.tags nowrap=true %}

--- a/themes/october-tricks/partials/trickDetail/trick.htm
+++ b/themes/october-tricks/partials/trickDetail/trick.htm
@@ -12,7 +12,7 @@
             </div>
         </div>
         <div class="trick__meta">
-            by {{ trick.author.username }}, last modified on {{ trick.updated_at.format('F jS, Y') }}
+            by <a href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>, last modified on {{ trick.updated_at.format('F jS, Y') }}
         </div>
         <div class="trick__tags">
             {% partial __SELF__ ~ '::tags' tags=trick.tags %}

--- a/themes/october-tricks/partials/trickDetail/trick.htm
+++ b/themes/october-tricks/partials/trickDetail/trick.htm
@@ -12,7 +12,7 @@
             </div>
         </div>
         <div class="trick__meta">
-            by <a class="author" href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>, last modified on {{ trick.updated_at.format('F jS, Y') }}
+            by <a class="author" href="{{ 'author-tricks' | page({username: trick.author.username}) }}">{{ trick.author.username }}</a>, last modified on {{ trick.updated_at.format('F jS, Y') }}
         </div>
         <div class="trick__tags">
             {% partial __SELF__ ~ '::tags' tags=trick.tags %}

--- a/themes/october-tricks/partials/trickDetail/trick.htm
+++ b/themes/october-tricks/partials/trickDetail/trick.htm
@@ -12,7 +12,7 @@
             </div>
         </div>
         <div class="trick__meta">
-            by <a href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>, last modified on {{ trick.updated_at.format('F jS, Y') }}
+            by <a class="author" href="/authors/{{trick.author.username}}/tricks">{{ trick.author.username }}</a>, last modified on {{ trick.updated_at.format('F jS, Y') }}
         </div>
         <div class="trick__tags">
             {% partial __SELF__ ~ '::tags' tags=trick.tags %}

--- a/themes/october-tricks/partials/trickListAuthor/default.htm
+++ b/themes/october-tricks/partials/trickListAuthor/default.htm
@@ -1,0 +1,9 @@
+<div class="medium-trick-list">
+    {% for trick in __SELF__.tricks %}
+        {% partial 'medium-trick' trick=trick forAccount=false %}
+    {% endfor %}
+</div>
+
+{% if __SELF__.tricks.hasPages %}
+    {{ __SELF__.tricks | raw }}
+{% endif %}

--- a/themes/october-tricks/resources/styl/base/base.styl
+++ b/themes/october-tricks/resources/styl/base/base.styl
@@ -38,8 +38,9 @@ a
     border-bottom 1px dotted
     color grey-dark
 
-.author:hover
-    color grey-darkest
+.author
+    &:hover
+        color grey-darkest
     
 hr
     border none

--- a/themes/october-tricks/resources/styl/base/base.styl
+++ b/themes/october-tricks/resources/styl/base/base.styl
@@ -34,6 +34,13 @@ a
     color primary
     text-decoration none
 
+.author
+    border-bottom 1px dotted
+    color grey-dark
+
+.author:hover
+    color grey-darkest
+    
 hr
     border none
     border-bottom 1px solid #ddd


### PR DESCRIPTION
The initial feature has been implemented by creating a new page and using the `TrickList` component. This component was updated to check for a username property, which is used to set the component's user based on the route parameter `:username`. If no user is found, the component will return the `404` page 

See #14 

**TODO**

- [x] Add links to author trick list from home page
- [x] Add link to author trick list from trick detail page
- [x] Update author trick list page title
- [x] Style author links differently (possible grey with dash under line, and orange hover state)
- [x] Fix issue with 404 page not showing search box. If you attempt to visit the trick list for an author that cannot be found, the search box is not displayed. Other invalid routes do show the search box on the 404 page.
