### PR TITLE
Fix mobile navigation z index

### DIFF
--- a/themes/october-tricks/resources/styl/components/header.styl
+++ b/themes/october-tricks/resources/styl/components/header.styl
@@ -1,6 +1,8 @@
 .header
     padding 2rem 0
     border-top 4px solid primary
+    position relative
+    z-index 9999
 
     .row--header
         margin 2rem 0


### PR DESCRIPTION
Set header to relative and add z index to make entire mobile nav viewable.

Fixes #18 